### PR TITLE
ci: add build image job and workflow

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -5,6 +5,9 @@ name: build
 
 on:
   workflow_call:
+    secrets:
+      NPMRC_FILE:
+        required: true
 
 concurrency:
   group: ${{ github.workflow }}-build-${{ github.event.pull_request.number || '' }}

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -60,3 +60,5 @@ jobs:
       contents: read
       packages: write
     uses: ./.github/workflows/build.yaml
+    secrets:
+      NPMRC_FILE: ${{ secrets.NPMRC_FILE }}


### PR DESCRIPTION
Add `build-image` job which uses the separate `build` workflow.